### PR TITLE
ユーザ名中のメンション、ハッシュタグ、URL自動リンクが働かないように修正

### DIFF
--- a/reply.php
+++ b/reply.php
@@ -20,7 +20,7 @@ if (!empty($res))
 	{
 		$param['status'] = sprintf('@%s %sさん'
 			, $re->user->screen_name
-			, $re->user->name
+			, trim(preg_replace('!([@＠#＃.]|://)!u', " $1 ", $re->user->name))
 			);
 		$param['in_reply_to_status_id'] = $re->id_str;
 		// 投稿


### PR DESCRIPTION
たとえば「`ちょまど@bot開発楽しい`」という名前のユーザがいた時に、`@bot`部分が実在する他人のscreen_nameと一致すると迷惑行為になってしまう。
これは、意図せず送信してしまう場合の他、嫌がらせで実際に攻撃が行われている。
これを @ の前後にスペースを挟むことで回避する。

その他、あまりリンクされてもうれしくないハッシュタグ、URLっぽい文字列についてもリンクされないようにする。

要検討事項:
スペース(U+0020)の代わりに、Zero-Width-Space(U+200B)を使用した方が見た目は良いが、RLO埋め込みのようにいつか無視されるようになるかもしれない。
