### PR TITLE
静的解析ツール PHPMD の導入

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,13 @@ depends-update: install-composer
 doc: depends-setup
 	vendor/bin/apigen generate --source="class" --destination="doc/api" --template-theme="bootstrap" --todo --tree --access-levels="public,protected,private" --internal
 
+phpmd:
+	vendor/bin/phpmd class text codesize,design,naming,unusedcode
+
 clean:
 	rm -rf doc vendor composer.phar
 
 composer.phar:
 	curl -sS https://getcomposer.org/installer | php
+
+.PHONY: all init install-composer depends-setup depends-update doc test phpmd clean

--- a/class/Log.php
+++ b/class/Log.php
@@ -9,6 +9,8 @@ namespace bot;
 
 /**
  * ログ出力を行うクラス
+ *
+ * @SuppressWarnings(PHPMD.TooManyMethods)
  */
 class Log {
     /**
@@ -158,6 +160,8 @@ class Log {
      * @param   string  $errfile    エラーが発生したファイルの名前
      * @param   int     $errline    エラーが発生した行番号
      * @return  bool この関数が FALSE を返した場合は、通常のエラーハンドラが処理を引き継ぎます
+     * 
+     * @SuppressWarnings(PHPMD.ExitExpression)
      */
     public static function errorHandlerCallback($errno, $errstr, $errfile, $errline) {
         // @で抑制されている場合等にも呼び出されるので、現在の設定と発生した内容を照らし合わせて
@@ -166,88 +170,7 @@ class Log {
             return true;
         }
 
-        $level  = 'info';
-        $die    = false;
-        $level_string = '?' . $errno . '?';
-        switch($errno) { // {{{
-        case E_ERROR: //実際にはハンドルできない
-            $level = 'error';
-            $die = true;
-            $level_string = 'E_ERROR';
-            break;
-        case E_WARNING:
-            $level = 'warning';
-            $die = false;
-            $level_string = 'E_WARNING';
-            break;
-        case E_PARSE: //実際にはハンドルできない
-            $level = 'error';
-            $die = true;
-            $level_string = 'E_PARSE';
-            break;
-        case E_NOTICE:
-            $level = 'info';
-            $die = false;
-            $level_string = 'E_NOTICE';
-            break;
-        case E_CORE_ERROR: //実際にはハンドルできない
-            $level = 'error';
-            $die = true;
-            $level_string = 'E_ERROR';
-            break;
-        case E_CORE_WARNING: //実際にはハンドルできない
-            $level = 'warning';
-            $die = false;
-            $level_string = 'E_CORE_WARNING';
-            break;
-        case E_COMPILE_ERROR: //実際にはハンドルできない
-            $level = 'error';
-            $die = true;
-            $level_string = 'E_COMPILE_ERROR';
-            break;
-        case E_COMPILE_WARNING: //実際にはハンドルできない
-            $level = 'warning';
-            $die = false;
-            $level_string = 'E_COMPILE_WARNING';
-            break;
-        case E_USER_ERROR:
-            $level = 'error';
-            $die = true;
-            $level_string = 'E_USER_ERROR';
-            break;
-        case E_USER_WARNING:
-            $level = 'warning';
-            $die = false;
-            $level_string = 'E_USER_WARNING';
-            break;
-        case E_USER_NOTICE:
-            $level = 'info';
-            $die = false;
-            $level_string = 'E_USER_NOTICE';
-            break;
-        case E_STRICT:
-            $level = 'info';
-            $die = false;
-            $level_string = 'E_STRICT';
-            break;
-        case E_RECOVERABLE_ERROR:
-            // ユーザー定義のハンドラでエラーがキャッチされなかった場合は、 E_ERROR として異常終了する
-            // とマニュアルに書いてあるので終了することにする
-            $level = 'error';
-            $die = true;
-            $level_string = 'E_RECOVERABLE_ERROR';
-            break;
-        case E_DEPRECATED:
-            $level = 'info';
-            $die = false;
-            $level_string = 'E_DEPRECATED';
-            break;
-        case E_USER_DEPRECATED:
-            $level = 'info';
-            $die = false;
-            $level_string = 'E_USER_DEPRECATED';
-            break;
-        } // }}}
+        list($level, $die, $level_string) = self::convertErrorNumber($errno);
         $output = sprintf(
             '[%s] %s at %s line %d',
             $level_string,
@@ -260,5 +183,35 @@ class Log {
             exit(1);
         }
         return true;
+    }
+
+    /**
+     * PHPの発生するエラー番号から情報を変換して取り扱えるようにする
+     *
+     * @internal
+     * @param   int     $errno      PHPの発生させたエラー番号
+     * @return  array               [ エラーレベル:string, 処理後スクリプトを終了するか:bool, エラー番号の文字列表現:string ]
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     */
+    private static function convertErrorNumber($errno) {
+        switch($errno) {
+        case E_ERROR:                   return ['error',   true,  'E_ERROR'];
+        case E_WARNING:                 return ['warning', false, 'E_WARNING'];
+        case E_PARSE:                   return ['error',   true,  'E_PARSE'];
+        case E_NOTICE:                  return ['info',    false, 'E_NOTICE'];
+        case E_CORE_ERROR:              return ['error',   true,  'E_CORE_ERROR'];
+        case E_CORE_WARNING:            return ['warning', false, 'E_CORE_WARNING'];
+        case E_COMPILE_ERROR:           return ['error',   true,  'E_COMPILE_ERROR'];
+        case E_COMPILE_WARNING:         return ['warning', false, 'E_COMPILE_WARNING'];
+        case E_USER_ERROR:              return ['error',   true,  'E_USER_ERROR'];
+        case E_USER_WARNING:            return ['warning', false, 'E_USER_WARNING'];
+        case E_USER_NOTICE:             return ['info',    false, 'E_USER_NOTICE'];
+        case E_STRICT:                  return ['info',    false, 'E_STRICT'];
+        case E_RECOVERABLE_ERROR:       return ['error',   true,  'E_RECOVERABLE_ERROR'];
+        case E_DEPRECATED:              return ['info',    false, 'E_DEPRECATED'];
+        case E_USER_DEPRECATED:         return ['info',    false, 'E_USER_DEPRECATED'];
+        }
+        return ['info', false, "?{$errno}?"];
     }
 }

--- a/class/Weather.php
+++ b/class/Weather.php
@@ -37,12 +37,12 @@ class Weather
     /**
      * 華氏から摂氏に変換する
      * 
-     * @param   float   $f  華氏温度
-     * @return  float       摂氏温度
+     * @param   float   $degree_fahrenheit  華氏温度
+     * @return  float                       摂氏温度
      */
-    private function FtoC($f)
+    private static function FtoC($degree_fahrenheit)
     {
-        return ((double)$f - 32) * 5 / 9;
+        return ((double)$degree_fahrenheit - 32) * 5 / 9;
     }
 
     /**
@@ -91,7 +91,7 @@ class Weather
     {
         return [
             'weather'   => Dictionary::GetJapanese($this->info->condition->code, $this->info->forecast[1]->text)
-            , 'temp'    => $this->FtoC($this->info->condition->temp)
+            , 'temp'    => self::FtoC($this->info->condition->temp)
         ];
     }
 
@@ -104,8 +104,8 @@ class Weather
     {
         return [
             'weather'   => Dictionary::GetJapanese($this->info->forecast[1]->code, $this->info->forecast[1]->text)
-            , 'high'    => $this->FtoC($this->info->forecast[1]->high)
-            , 'low'     => $this->FtoC($this->info->forecast[1]->low)
+            , 'high'    => self::FtoC($this->info->forecast[1]->high)
+            , 'low'     => self::FtoC($this->info->forecast[1]->low)
         ];
     }
 

--- a/class/log/File.php
+++ b/class/log/File.php
@@ -37,7 +37,7 @@ class File extends TargetAbstract {
      * このクラスが生成された時に対象ファイルは固定される。
      * （途中で日付が変わっても何事もなかったかのように処理される）
      */
-    private $fh = null;
+    private $log_handle = null;
 
     /**
      * コンストラクタ
@@ -49,7 +49,7 @@ class File extends TargetAbstract {
         if(!file_exists(dirname($log_file_path))) {
             mkdir(dirname($log_file_path), 0755, true);
         }
-        if(!$this->fh = fopen($log_file_path, 'c+t')) {
+        if(!$this->log_handle = fopen($log_file_path, 'c+t')) {
             throw new \Exception('Could not open log file: ' . $log_file_path);
         }
     }
@@ -61,8 +61,8 @@ class File extends TargetAbstract {
      */
     public function __destruct() {
         $this->flush();
-        fclose($this->fh);
-        $this->fh = null;
+        fclose($this->log_handle);
+        $this->log_handle = null;
     }
 
     /**
@@ -92,14 +92,14 @@ class File extends TargetAbstract {
      * バッファにたまったログをファイルに書き出す
      */
     private function flush() {
-        if(!$this->fh || !$this->buffer) {
+        if(!$this->log_handle || !$this->buffer) {
             return;
         }
-        flock($this->fh, LOCK_EX);
-        fseek($this->fh, 0, SEEK_END);
-        fwrite($this->fh, implode("\n", $this->buffer) . "\n");
-        fflush($this->fh);
-        flock($this->fh, LOCK_UN);
+        flock($this->log_handle, LOCK_EX);
+        fseek($this->log_handle, 0, SEEK_END);
+        fwrite($this->log_handle, implode("\n", $this->buffer) . "\n");
+        fflush($this->log_handle);
+        flock($this->log_handle, LOCK_UN);
         $this->buffer = [];
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     },
     "require-dev": {
         "apigen/apigen": "~4.0",
-        "apigen/theme-bootstrap": "~1.0"
+        "apigen/theme-bootstrap": "~1.0",
+        "phpmd/phpmd": "~2.2"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "83f4e42675d11b3d8923a5239dae8b45",
+    "hash": "fda48395b177ba6bb306790413b6ae47",
     "packages": [
         {
             "name": "abraham/twitteroauth",
@@ -1534,6 +1534,106 @@
             "time": "2014-12-30 09:55:38"
         },
         {
+            "name": "pdepend/pdepend",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pdepend/pdepend.git",
+                "reference": "1b0acf162da4f30237987e61e177a57f78e3d87e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pdepend/pdepend/zipball/1b0acf162da4f30237987e61e177a57f78e3d87e",
+                "reference": "1b0acf162da4f30237987e61e177a57f78e3d87e",
+                "shasum": ""
+            },
+            "require": {
+                "symfony/config": ">=2.4",
+                "symfony/dependency-injection": ">=2.4",
+                "symfony/filesystem": ">=2.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*@stable",
+                "squizlabs/php_codesniffer": "@stable"
+            },
+            "bin": [
+                "src/bin/pdepend"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "PDepend\\": "src/main/php/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Official version of pdepend to be handled with Composer",
+            "time": "2014-12-04 12:38:39"
+        },
+        {
+            "name": "phpmd/phpmd",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpmd/phpmd.git",
+                "reference": "580e6ca75b472a844389ab8df7a0b412901d0d91"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpmd/phpmd/zipball/580e6ca75b472a844389ab8df7a0b412901d0d91",
+                "reference": "580e6ca75b472a844389ab8df7a0b412901d0d91",
+                "shasum": ""
+            },
+            "require": {
+                "pdepend/pdepend": "2.0.*",
+                "php": ">=5.3.0",
+                "symfony/config": ">=2.4",
+                "symfony/dependency-injection": ">=2.4",
+                "symfony/filesystem": ">=2.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "*"
+            },
+            "bin": [
+                "src/bin/phpmd"
+            ],
+            "type": "project",
+            "autoload": {
+                "psr-0": {
+                    "PHPMD\\": "src/main/php"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Manuel Pichler",
+                    "email": "github@manuel-pichler.de",
+                    "homepage": "https://github.com/manuelpichler",
+                    "role": "Project founder"
+                },
+                {
+                    "name": "Other contributors",
+                    "homepage": "https://github.com/phpmd/phpmd/graphs/contributors",
+                    "role": "Contributors"
+                }
+            ],
+            "description": "PHPMD is a spin-off project of PHP Depend and aims to be a PHP equivalent of the well known Java tool PMD.",
+            "homepage": "http://phpmd.org/",
+            "keywords": [
+                "mess detection",
+                "mess detector",
+                "pdepend",
+                "phpmd",
+                "pmd"
+            ],
+            "time": "2015-01-25 13:46:59"
+        },
+        {
             "name": "seld/jsonlint",
             "version": "1.3.1",
             "source": {
@@ -1578,6 +1678,54 @@
                 "validator"
             ],
             "time": "2015-01-04 21:18:15"
+        },
+        {
+            "name": "symfony/config",
+            "version": "v2.6.4",
+            "target-dir": "Symfony/Component/Config",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Config.git",
+                "reference": "a9f781ba1221067d1f07c8cec0bc50f81b8d7408"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Config/zipball/a9f781ba1221067d1f07c8cec0bc50f81b8d7408",
+                "reference": "a9f781ba1221067d1f07c8cec0bc50f81b8d7408",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "symfony/filesystem": "~2.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Config\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Symfony Config Component",
+            "homepage": "http://symfony.com",
+            "time": "2015-01-21 20:57:55"
         },
         {
             "name": "symfony/console",
@@ -1635,6 +1783,113 @@
             "description": "Symfony Console Component",
             "homepage": "http://symfony.com",
             "time": "2015-01-25 04:39:26"
+        },
+        {
+            "name": "symfony/dependency-injection",
+            "version": "v2.6.4",
+            "target-dir": "Symfony/Component/DependencyInjection",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/DependencyInjection.git",
+                "reference": "42bbb43fab66292a1865dc9616c299904c3d4d14"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/DependencyInjection/zipball/42bbb43fab66292a1865dc9616c299904c3d4d14",
+                "reference": "42bbb43fab66292a1865dc9616c299904c3d4d14",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "conflict": {
+                "symfony/expression-language": "<2.6"
+            },
+            "require-dev": {
+                "symfony/config": "~2.2",
+                "symfony/expression-language": "~2.6",
+                "symfony/yaml": "~2.1"
+            },
+            "suggest": {
+                "symfony/config": "",
+                "symfony/proxy-manager-bridge": "Generate service proxies to lazy load them",
+                "symfony/yaml": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\DependencyInjection\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Symfony DependencyInjection Component",
+            "homepage": "http://symfony.com",
+            "time": "2015-01-25 04:39:26"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v2.6.4",
+            "target-dir": "Symfony/Component/Filesystem",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Filesystem.git",
+                "reference": "a1f566d1f92e142fa1593f4555d6d89e3044a9b7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/a1f566d1f92e142fa1593f4555d6d89e3044a9b7",
+                "reference": "a1f566d1f92e142fa1593f4555d6d89e3044a9b7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Symfony Filesystem Component",
+            "homepage": "http://symfony.com",
+            "time": "2015-01-03 21:13:09"
         },
         {
             "name": "symfony/options-resolver",


### PR DESCRIPTION
[PHPMD](http://phpmd.org/) を導入し、コードを対応させます。
このコード微調整で[他の静的解析結果](https://scrutinizer-ci.com/g/fetus-hina/chomado_bot/?branch=phpmd)でもより高評価になりました。

デフォルトの値が少し厳しすぎるように思えるので従いすぎるのも問題になりそうですが、
開発の参考にはできると思います。

`make phpmd` で実行できます。

composer.json と composer.lock が変更になるので `composer.phar install` が必要です。
